### PR TITLE
Validate SQL input before execution

### DIFF
--- a/Tools/Command/CommandTools.cs
+++ b/Tools/Command/CommandTools.cs
@@ -353,6 +353,11 @@ internal class CommandTools
 
     private void EnsureSafeSql(string sql)
     {
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            throw new DatabaseMcpException(DatabaseErrorCode.InvalidParameters, "SQL 语句不能为空");
+        }
+
         if (_databaseHelper.DetectDangerousOperation(sql))
         {
             throw new DatabaseMcpException(DatabaseErrorCode.DangerousOperation,

--- a/Tools/Query/QueryTools.cs
+++ b/Tools/Query/QueryTools.cs
@@ -453,6 +453,11 @@ internal class QueryTools
 
     private void EnsureSafeSql(string sql)
     {
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            throw new DatabaseMcpException(DatabaseErrorCode.InvalidParameters, "SQL 语句不能为空");
+        }
+
         if (_databaseHelper.DetectDangerousOperation(sql))
         {
             throw new DatabaseMcpException(DatabaseErrorCode.DangerousOperation, "检测到潜在危险操作，请使用 Schema 工具执行结构变更。");


### PR DESCRIPTION
## Summary
- add explicit empty-SQL validation before executing commands or queries
- return structured invalid-parameter errors instead of hitting the database with blank statements

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935b661d20c8322a5da6a2ff884194c)